### PR TITLE
Add initState to home.dart for urlImage()

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -11,8 +11,13 @@ class Home extends StatefulWidget {
 class _HomeState extends State<Home> {
   final Future<String?> theTime = getTheTime();
   final Future<String?> theLocation = getTheLocation();
-  final String theDay = urlImage();  
+  late String theDay; 
 
+  @override
+  void initState(){
+    theDay = urlImage();
+  }
+  
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -16,6 +16,7 @@ class _HomeState extends State<Home> {
   @override
   void initState(){
     theDay = urlImage();
+    super.initState();
   }
   
   @override


### PR DESCRIPTION
add initState() - is a method which is called once when the stateful widget is inserted in the widget tree. 
we use it for one time initializations.

Example :
- To initialize data that depends on the specific BuildContext.
- To initialize data that needs to executed before build().-----------------> I believe this is our case. Try it
- Subscribe to Streams.

Try this,if it doesnt work we just wrap the assetimage widget in a future builder