### PR TITLE
Added initState to home.dart

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -11,7 +11,7 @@ class Home extends StatefulWidget {
 class _HomeState extends State<Home> {
   final Future<String?> theTime = getTheTime();
   final Future<String?> theLocation = getTheLocation();
-  late String theDay; 
+  late String theDay;
 
   @override
   void initState(){


### PR DESCRIPTION
add initState() - is a method which is called once when the stateful widget is inserted in the widget tree.
we use it for one time initializations.

Example :

To initialize data that depends on the specific BuildContext.
To initialize data that needs to executed before build().-----------------> I believe this is our case. Try it
Subscribe to Streams.
Try this,if it doesnt work we just wrap the assetimage widget in a future builder